### PR TITLE
OpenMW specific changes

### DIFF
--- a/ports/mygui/platform-lib-static.patch
+++ b/ports/mygui/platform-lib-static.patch
@@ -1,0 +1,91 @@
+diff --git a/Platforms/DirectX/DirectXPlatform/CMakeLists.txt b/Platforms/DirectX/DirectXPlatform/CMakeLists.txt
+index 169a2afe4..2ea45af2b 100644
+--- a/Platforms/DirectX/DirectXPlatform/CMakeLists.txt
++++ b/Platforms/DirectX/DirectXPlatform/CMakeLists.txt
+@@ -9,7 +9,7 @@ include_directories(
+ 
+ include(${PROJECTNAME}.list)
+ 
+-add_library(${PROJECTNAME} ${HEADER_FILES} ${SOURCE_FILES})
++add_library(${PROJECTNAME} STATIC ${HEADER_FILES} ${SOURCE_FILES})
+ 
+ add_dependencies(${PROJECTNAME} MyGUIEngine)
+ 
+diff --git a/Platforms/DirectX11/DirectX11Platform/CMakeLists.txt b/Platforms/DirectX11/DirectX11Platform/CMakeLists.txt
+index 251fcdbe3..16d4f33a5 100644
+--- a/Platforms/DirectX11/DirectX11Platform/CMakeLists.txt
++++ b/Platforms/DirectX11/DirectX11Platform/CMakeLists.txt
+@@ -9,7 +9,7 @@ include_directories(
+ 
+ include(${PROJECTNAME}.list)
+ 
+-add_library(${PROJECTNAME} ${HEADER_FILES} ${SOURCE_FILES})
++add_library(${PROJECTNAME} STATIC ${HEADER_FILES} ${SOURCE_FILES})
+ 
+ add_dependencies(${PROJECTNAME} MyGUIEngine)
+ 
+diff --git a/Platforms/Dummy/DummyPlatform/CMakeLists.txt b/Platforms/Dummy/DummyPlatform/CMakeLists.txt
+index 1055694f2..625391132 100644
+--- a/Platforms/Dummy/DummyPlatform/CMakeLists.txt
++++ b/Platforms/Dummy/DummyPlatform/CMakeLists.txt
+@@ -8,7 +8,7 @@ include_directories(
+ 
+ include(${PROJECTNAME}.list)
+ 
+-add_library(${PROJECTNAME} ${HEADER_FILES} ${SOURCE_FILES})
++add_library(${PROJECTNAME} STATIC ${HEADER_FILES} ${SOURCE_FILES})
+ 
+ add_dependencies(${PROJECTNAME} MyGUIEngine)
+ 
+diff --git a/Platforms/Ogre/OgrePlatform/CMakeLists.txt b/Platforms/Ogre/OgrePlatform/CMakeLists.txt
+index a151abcf8..23f8a2373 100644
+--- a/Platforms/Ogre/OgrePlatform/CMakeLists.txt
++++ b/Platforms/Ogre/OgrePlatform/CMakeLists.txt
+@@ -8,7 +8,7 @@ include_directories(
+ 
+ include(${PROJECTNAME}.list)
+ 
+-add_library(${PROJECTNAME} ${HEADER_FILES} ${SOURCE_FILES})
++add_library(${PROJECTNAME} STATIC ${HEADER_FILES} ${SOURCE_FILES})
+ 
+ add_dependencies(${PROJECTNAME} MyGUIEngine)
+ 
+diff --git a/Platforms/OpenGL/OpenGLPlatform/CMakeLists.txt b/Platforms/OpenGL/OpenGLPlatform/CMakeLists.txt
+index 0d58d3d71..78eaf0267 100644
+--- a/Platforms/OpenGL/OpenGLPlatform/CMakeLists.txt
++++ b/Platforms/OpenGL/OpenGLPlatform/CMakeLists.txt
+@@ -19,7 +19,7 @@ if (NOT MYGUI_USE_SYSTEM_GLEW)
+ endif ()
+ add_definitions(-DGL_GLEXT_PROTOTYPES)
+ 
+-add_library(${PROJECTNAME} ${HEADER_FILES} ${SOURCE_FILES})
++add_library(${PROJECTNAME} STATIC ${HEADER_FILES} ${SOURCE_FILES})
+ 
+ add_dependencies(${PROJECTNAME} MyGUIEngine)
+ 
+diff --git a/Platforms/OpenGL3/OpenGL3Platform/CMakeLists.txt b/Platforms/OpenGL3/OpenGL3Platform/CMakeLists.txt
+index 27d96da3e..4dcee1601 100644
+--- a/Platforms/OpenGL3/OpenGL3Platform/CMakeLists.txt
++++ b/Platforms/OpenGL3/OpenGL3Platform/CMakeLists.txt
+@@ -19,7 +19,7 @@ if (NOT MYGUI_USE_SYSTEM_GLEW)
+ endif ()
+ add_definitions(-DGL_GLEXT_PROTOTYPES)
+ 
+-add_library(${PROJECTNAME} ${HEADER_FILES} ${SOURCE_FILES})
++add_library(${PROJECTNAME} STATIC ${HEADER_FILES} ${SOURCE_FILES})
+ 
+ add_dependencies(${PROJECTNAME} MyGUIEngine)
+ 
+diff --git a/Platforms/OpenGLES/OpenGLESPlatform/CMakeLists.txt b/Platforms/OpenGLES/OpenGLESPlatform/CMakeLists.txt
+index bd6d9657b..ad31fc158 100644
+--- a/Platforms/OpenGLES/OpenGLESPlatform/CMakeLists.txt
++++ b/Platforms/OpenGLES/OpenGLESPlatform/CMakeLists.txt
+@@ -9,7 +9,7 @@ include_directories(
+ 
+ include(${PROJECTNAME}.list)
+ add_definitions(-DGL_GLEXT_PROTOTYPES)
+-add_library(${PROJECTNAME} ${HEADER_FILES} ${SOURCE_FILES})
++add_library(${PROJECTNAME} STATIC ${HEADER_FILES} ${SOURCE_FILES})
+ 
+ add_dependencies(${PROJECTNAME} MyGUIEngine)
+ 

--- a/ports/mygui/portfile.cmake
+++ b/ports/mygui/portfile.cmake
@@ -26,7 +26,11 @@ endif()
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
+        plugins MYGUI_BUILD_PLUGINS
         tools MYGUI_BUILD_TOOLS
+    INVERTED_FEATURES
+        obsolete MYGUI_DONT_USE_OBSOLETE
+        plugins MYGUI_DISABLE_PLUGINS
 )
 
 vcpkg_cmake_configure(
@@ -34,7 +38,6 @@ vcpkg_cmake_configure(
     OPTIONS
         -DMYGUI_STATIC=TRUE
         -DMYGUI_BUILD_DEMOS=FALSE
-        -DMYGUI_BUILD_PLUGINS=TRUE
         -DMYGUI_BUILD_UNITTESTS=FALSE
         -DMYGUI_BUILD_TEST_APP=FALSE
         -DMYGUI_BUILD_WRAPPER=FALSE

--- a/ports/mygui/portfile.cmake
+++ b/ports/mygui/portfile.cmake
@@ -1,7 +1,3 @@
-# MyGUI supports compiling itself as a DLL,
-# but it seems platform-related stuff doesn't support dynamic linkage
-vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
-
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO MyGUI/mygui
@@ -13,6 +9,7 @@ vcpkg_from_github(
         Install-tools.patch
         opengl.patch
         sdl2-static.patch
+        platform-lib-static.patch
 )
 
 if(VCPKG_TARGET_ARCHITECTURE STREQUAL "wasm32")
@@ -33,10 +30,12 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
         plugins MYGUI_DISABLE_PLUGINS
 )
 
+string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" MYGUI_STATIC)
+
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
-        -DMYGUI_STATIC=TRUE
+        -DMYGUI_STATIC=${MYGUI_STATIC}
         -DMYGUI_BUILD_DEMOS=FALSE
         -DMYGUI_BUILD_UNITTESTS=FALSE
         -DMYGUI_BUILD_TEST_APP=FALSE

--- a/ports/mygui/vcpkg.json
+++ b/ports/mygui/vcpkg.json
@@ -26,6 +26,12 @@
     },
     "tools": {
       "description": "Install MyGUI tools."
+    },
+    "plugins": {
+      "description": "Build MyGUI plugins."
+    },
+    "obsolete": {
+      "description": "Keep obsolete functions."
     }
   }
 }

--- a/ports/openmw-osg/portfile.cmake
+++ b/ports/openmw-osg/portfile.cmake
@@ -1,0 +1,91 @@
+set(VCPKG_POLICY_DLLS_WITHOUT_EXPORTS enabled)
+
+set(OSG_VER 3.6.5)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO openmw/osg
+    REF 2ad03d69e3b3e3781de9e96384225b0cbdefdd58
+    SHA512 8a124293349a8bac436bd83b9f60b50c7a684bab7c0a19610c2bd70f6d424c652de8443ee365354d960fff431bb04bf5b62eea7b2e45a828c622b7ab6233e3ff
+    HEAD_REF 3.6
+)
+
+file(REMOVE
+    "${SOURCE_PATH}/CMakeModules/FindFontconfig.cmake"
+    "${SOURCE_PATH}/CMakeModules/FindFreetype.cmake"
+    "${SOURCE_PATH}/CMakeModules/Findilmbase.cmake"
+    "${SOURCE_PATH}/CMakeModules/FindOpenEXR.cmake"
+    "${SOURCE_PATH}/CMakeModules/FindSDL2.cmake"
+)
+
+string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" OSG_DYNAMIC)
+
+set(OPTIONS "")
+
+# Skip try_run checks
+if(VCPKG_TARGET_IS_MINGW)
+    list(APPEND OPTIONS -D_OPENTHREADS_ATOMIC_USE_WIN32_INTERLOCKED=0 -D_OPENTHREADS_ATOMIC_USE_GCC_BUILTINS=1)
+elseif(VCPKG_TARGET_IS_WINDOWS)
+    list(APPEND OPTIONS -D_OPENTHREADS_ATOMIC_USE_WIN32_INTERLOCKED=1 -D_OPENTHREADS_ATOMIC_USE_GCC_BUILTINS=0)
+elseif(VCPKG_TARGET_IS_IOS)
+    # handled by osg
+elseif(VCPKG_CROSSCOMPILING)
+    message(WARNING "Atomics detection may fail for cross builds. You can set osg cmake variables in a custom triplet.")
+endif()
+
+# The package osg can be configured to use different OpenGL profiles via a custom triplet file:
+# Possible values are GLCORE, GL2, GL3, GLES1, GLES2, GLES3, and GLES2+GLES3
+if(NOT DEFINED osg_OPENGL_PROFILE)
+    set(osg_OPENGL_PROFILE "GL2")
+endif()
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DDYNAMIC_OPENSCENEGRAPH=${OSG_DYNAMIC}
+        -DDYNAMIC_OPENTHREADS=${OSG_DYNAMIC}
+        -DOSG_MSVC_VERSIONED_DLL=OFF
+        -DOSG_DETERMINE_WIN_VERSION=OFF
+        -DOSG_FIND_3RD_PARTY_DEPS=OFF
+        -DOPENGL_PROFILE=${osg_OPENGL_PROFILE}
+        -DBUILD_DASHBOARD_REPORTS=OFF
+        -DCMAKE_CXX_STANDARD=11
+        -DPKG_CONFIG_USE_CMAKE_PREFIX_PATH=ON
+        -DBUILD_OSG_PLUGINS_BY_DEFAULT=OFF
+        -DBUILD_OSG_PLUGIN_OSG=ON
+        -DBUILD_OSG_PLUGIN_DDS=ON
+        -DBUILD_OSG_PLUGIN_TGA=ON
+        -DBUILD_OSG_PLUGIN_BMP=ON
+        -DBUILD_OSG_PLUGIN_JPEG=ON
+        -DBUILD_OSG_PLUGIN_PNG=ON
+        -DBUILD_OSG_PLUGIN_FREETYPE=ON
+        -DBUILD_OSG_PLUGIN_DAE=ON
+        -DBUILD_OSG_PLUGIN_KTX=ON
+        -DBUILD_OSG_DEPRECATED_SERIALIZERS=OFF
+        -DBUILD_OSG_APPLICATIONS=OFF
+        -DBUILD_OSG_EXAMPLES=OFF
+        -DBUILD_DOCUMENTATION=OFF
+        ${OPTIONS}
+    MAYBE_UNUSED_VARIABLES
+        OSG_DETERMINE_WIN_VERSION
+)
+vcpkg_cmake_install()
+vcpkg_copy_pdbs()
+
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+    file(APPEND "${CURRENT_PACKAGES_DIR}/include/osg/Config" "#ifndef OSG_LIBRARY_STATIC\n#define OSG_LIBRARY_STATIC 1\n#endif\n")
+endif()
+
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/debug/include"
+    "${CURRENT_PACKAGES_DIR}/debug/share"
+)
+
+vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/lib/pkgconfig/openscenegraph.pc" "\\\n" " ")
+if(NOT VCPKG_BUILD_TYPE)
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/openscenegraph.pc" "\\\n" " ")
+endif()
+vcpkg_fixup_pkgconfig()
+
+file(COPY "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+file(INSTALL "${SOURCE_PATH}/LICENSE.txt" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/openmw-osg/usage
+++ b/ports/openmw-osg/usage
@@ -1,0 +1,4 @@
+The package osg can be configured to use different OpenGL profiles via a custom triplet file.
+Possible values are GLCORE, GL2, GL3, GLES1, GLES2, GLES3 and GLES2+GLES3.
+The default value is GL3.
+set(osg_OPENGL_PROFILE GL2)

--- a/ports/openmw-osg/vcpkg.json
+++ b/ports/openmw-osg/vcpkg.json
@@ -1,0 +1,28 @@
+{
+  "name": "openmw-osg",
+  "version": "3.6.5",
+  "port-version": 1,
+  "description": "Fork of OpenSceneGraph for OpenMW-specific performance improvements.",
+  "homepage": "https://github.com/openmw/osg",
+  "license": null,
+  "supports": "!uwp",
+  "dependencies": [
+    "collada-dom",
+    "freetype",
+    "libiconv",
+    "libjpeg-turbo",
+    "libpng",
+    "libxml2",
+    "opengl-registry",
+    "tiff",
+    "zlib",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}


### PR DESCRIPTION
* Add a new port openmw-osg to build package for https://github.com/OpenMW/osg. It has just basic support for options OpenMW needs like specific set of plugins.
* Add support for dynamic linking to MyGUI. vcpkg support only static libraries for it due to issues in the platform libraries. Make those libraries static and make main one to support static and dynamic linking.
* Add features to MyGUI to make the build compatible with OpenMW. Add `MYGUI_DONT_USE_OBSOLETE` macro support and ability to disable unused options.